### PR TITLE
Fix some build problems

### DIFF
--- a/types/dune
+++ b/types/dune
@@ -30,5 +30,6 @@
   $(< ../config/wlroots-ccopt) $(< ../config/wlroots-cclib) \
   $(< ../config/wayland-server-ccopt) $(< ../config/wayland-server-cclib) \
   $(< ../config/pixman-1-ccopt) $(< ../config/pixman-1-cclib) \
+  -DWLR_USE_UNSTABLE \
   -I `dirname %{lib:ctypes:ctypes_cstubs_internals.h}` \
   -I %{ocaml_where} -o %{targets}")))

--- a/wlroots.opam
+++ b/wlroots.opam
@@ -1,13 +1,10 @@
+opam-version: "2.0"
 maintainer: "Armael <armael@isomorphis.me>"
 authors: "Armael <armael@isomorphis.me>"
 homepage: "https://github.com/swaywm/wlroots-ocaml"
 bug-reports: "https://github.com/swaywm/wlroots-ocaml/issues"
-opam-version: "1.2"
-build: [
-  ["dune" "build" "-p" name "-j" jobs "@install"]
-]
 depends: [
-#  "conf-wlroots"
+  "ocaml" {>= "4.04.1"}
   "ctypes"
   "ctypes-foreign"
   "dune"
@@ -16,4 +13,4 @@ depends: [
   "base"
   "stdio"
 ]
-available: [ ocaml-version >= "4.04.1" ]
+build: ["dune" "build" "-p" name "-j" jobs "@install"]

--- a/wlroots.opam
+++ b/wlroots.opam
@@ -4,14 +4,16 @@ homepage: "https://github.com/swaywm/wlroots-ocaml"
 bug-reports: "https://github.com/swaywm/wlroots-ocaml/issues"
 opam-version: "1.2"
 build: [
-  ["jbuilder" "build" "-p" name "-j" jobs]
+  ["dune" "build" "-p" name "-j" jobs "@install"]
 ]
 depends: [
 #  "conf-wlroots"
   "ctypes"
   "ctypes-foreign"
-  "jbuilder"                {build & >= "1.0+beta12"}
+  "dune"
   "unix-time"
   "mtime"
+  "base"
+  "stdio"
 ]
 available: [ ocaml-version >= "4.04.1" ]


### PR DESCRIPTION
- Fix dependencies in opam file (and upgrade to opam 2).
- Add missing `-DWLR_USE_UNSTABLE`.

Error was:

    In file included from types_stubgen.c:4:
    /usr/include/wlr/backend.h:6:2: error: #error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
        6 | #error "Add -DWLR_USE_UNSTABLE to enable unstable wlroots features"
          |  ^~~~~

Note: the project still doesn't build, due to other upstream API changes. I don't know how to fix those. Would be good to enable CI for this repository.