### PR TITLE
[WIP] Fix compilation on old wlroots by changing return types to unit

### DIFF
--- a/ffi/ffi.ml
+++ b/ffi/ffi.ml
@@ -183,14 +183,14 @@ struct
       (wlr_renderer_p @-> ptr float @-> returning void)
 
   let wlr_renderer_init_wl_display = foreign "wlr_renderer_init_wl_display"
-      (wlr_renderer_p @-> wl_display_p @-> returning bool)
+      (wlr_renderer_p @-> wl_display_p @-> returning void)
 
   (* wlr_keyboard *)
 
   let wlr_keyboard_p = ptr Keyboard.t
 
   let wlr_keyboard_set_keymap = foreign "wlr_keyboard_set_keymap"
-      (wlr_keyboard_p @-> Xkbcommon.Keymap.t @-> returning bool)
+      (wlr_keyboard_p @-> Xkbcommon.Keymap.t @-> returning void)
 
   (* wlr_backend *)
 

--- a/lib/wlroots.mli
+++ b/lib/wlroots.mli
@@ -128,7 +128,7 @@ module Keyboard : sig
 
   val xkb_state : t -> Xkbcommon.State.t
   val signal_key : t -> Event_key.t Wl.Signal.t
-  val set_keymap : t -> Xkbcommon.Keymap.t -> bool
+  val set_keymap : t -> Xkbcommon.Keymap.t -> unit
 end
 
 module Pointer : sig
@@ -187,7 +187,7 @@ module Renderer : sig
   val begin_ : t -> width:int -> height:int -> unit
   val end_ : t -> unit
   val clear : t -> float * float * float * float -> unit
-  val init_wl_display : t -> Wl.Display.t -> bool
+  val init_wl_display : t -> Wl.Display.t -> unit
 end
 
 module Backend : sig


### PR DESCRIPTION
Hi,

This isn't an actual PR I intend to merge, just letting you know that this builds with wlroots 0.10.0.
I think the proper way to go about it in C would be some kind of ifdef, but I don't know the details of the Ffi module yet. I guess I'd just return true on the ocaml side, in case of the old version of the library...

Best regards,
Moritz